### PR TITLE
Use gunicorn in production build

### DIFF
--- a/Dockerfile.concourse
+++ b/Dockerfile.concourse
@@ -4,10 +4,11 @@ RUN mkdir data
 COPY data data/
 
 COPY .env.default .
+COPY gunicorn_config.py .
 
 COPY dist/dp_nlp_berlin_api-*-py3-none-any.whl .
 
 RUN pip install dp_nlp_berlin_api-*-py3-none-any.whl
 
-CMD ["python", "-m", "app.main"]
+CMD ["python", "-m", "gunicorn", "app.main:create_app()", "-c", "gunicorn_config.py"]
 

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -7,5 +7,6 @@ pushd dp-nlp-berlin-api
   mv dist/ $cwd/build
   mv data/ $cwd/build
   cp Dockerfile.concourse $cwd/build
+  cp gunicorn_config.py $cwd/build
   cp .env.default $cwd/build
 popd

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -106,3 +106,5 @@ logconfig_dict = {
         },
     },
 }
+
+bind = f"0.0.0.0:{settings.PORT}"


### PR DESCRIPTION
### What

`Dockerfile.concourse` now runs gunicorn explicitly, and `gunicorn_config.py` is added into the final image during Concourse CI.

### How to review

Make sure the CI built image runs with `gunicorn` at the right settings PORT. This should be sufficient to confirm that `gunicorn_config.py` is being used. 

### Who can review

Phil worked on the changes, Linden can review.
