### PR TITLE
Add logging compliance test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ run: deps ## Start the api locally on port 28900.
 	@FLASK_APP=${FLASK_APP} poetry run gunicorn "app.main:create_app()" -b 0.0.0.0:${BERLIN_API_PORT} -c gunicorn_config.py
 
 run-container: build ## Runs a container from the pre-build image 
-	docker run -p 28940:28900 --env BERLIN_API_BUILD_TIME='${BERLIN_API_BUILD_TIME}' -e BERLIN_API_BUILD_TIME="${BERLIN_API_BUILD_TIME}" -e BERLIN_API_VERSION="${BERLIN_API_VERSION}" -ti berlin_api
+	docker run -p 28900:28900 --env BERLIN_API_BUILD_TIME='${BERLIN_API_BUILD_TIME}' -e BERLIN_API_BUILD_TIME="${BERLIN_API_BUILD_TIME}" -e BERLIN_API_VERSION="${BERLIN_API_VERSION}" -ti berlin_api
 
 test: deps ## runs all tests
 	poetry run pytest -v tests/

--- a/app/logger.py
+++ b/app/logger.py
@@ -1,12 +1,12 @@
 import logging
 import logging.config
-import traceback
 from datetime import datetime
 
 import structlog
 import structlog._log_levels
 
 from app.settings import settings
+from gunicorn_config import format_stack_trace
 
 
 def add_severity_level(logger, method_name, event_dict):
@@ -17,24 +17,21 @@ def add_severity_level(logger, method_name, event_dict):
 
     return event_dict
 
-def format_errors(*excs: BaseException):
+
+def format_errors(*excs: BaseException, trace=None):
     errors = []
 
     for exc in excs:
         error = {
             "message": str(exc),
-            "data": {
-                "level": "ERROR"
-            }
         }
-        try:
-            stack_trace = traceback.extract_tb(exc.__traceback__).format()
-            error["stack_trace"] = stack_trace
-        except Exception as e:
-            print(e)
-            ...
+        if trace:
+            error["error"] = format_stack_trace(trace)
+
         errors.append(error)
+
     return errors
+
 
 def setup_logging():
     shared_processors = []
@@ -85,3 +82,6 @@ def setup_logging():
         event="",
         severity=3,  # default
     )
+
+
+logger = setup_logging()

--- a/app/main.py
+++ b/app/main.py
@@ -1,18 +1,14 @@
 from flask import Flask
 
-from app.logger import setup_logging
 from app.settings import settings
 from app.views.berlin import berlin_blueprint
 from app.views.health import health_blueprint
-
-logger = setup_logging()
 
 
 def create_app():
     application = Flask(__name__)
     application.register_blueprint(berlin_blueprint)
     application.register_blueprint(health_blueprint)
-    raise Exception("Intentional crash during Gunicorn startup")
     return application
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ def create_app():
     application = Flask(__name__)
     application.register_blueprint(berlin_blueprint)
     application.register_blueprint(health_blueprint)
+    raise Exception("Intentional crash during Gunicorn startup")
     return application
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -1,11 +1,10 @@
+import traceback
 from dataclasses import asdict, dataclass
 from typing import Optional
 
 from berlin import Location
 
-from app.logger import setup_logging
-
-logger = setup_logging()
+from app.logger import format_errors, logger
 
 
 @dataclass
@@ -17,8 +16,11 @@ class MatchModel:
     def from_location(cls, loc: Location) -> "MatchModel":
         try:
             return cls(score=loc.get_score(), offset=loc.get_offset())
-        except AttributeError:
-            logger.error("no offset or score available")
+        except AttributeError as e:
+            logger.error(
+                event="no offset or score available",
+                errors=format_errors(e, trace=traceback.format_exc()),
+            )
 
     def to_json(self):
         return asdict(self)

--- a/app/store.py
+++ b/app/store.py
@@ -1,12 +1,20 @@
 import functools
+import traceback
 from typing import Optional
 
 from berlin import load
 
+from app.logger import format_errors, logger
 from app.settings import settings
 
 
 @functools.lru_cache
 def get_db(location: Optional[str] = None):
-    db = load(location or settings.DATA_LOCATION)
-    return db
+    try:
+        db = load(location or settings.DATA_LOCATION)
+        return db
+    except Exception as e:
+        logger.error(
+            event="unable to load database",
+            errors=format_errors(e, trace=traceback.format_exc()),
+        )

--- a/app/views/berlin.py
+++ b/app/views/berlin.py
@@ -1,10 +1,11 @@
+import traceback
+
 from flask import Blueprint, jsonify, request
 
-from app.logger import setup_logging, format_errors
+from app.logger import format_errors, logger
 from app.models import LocationModel, MatchModel
 from app.store import get_db
 
-logger = setup_logging()
 db = get_db()
 
 berlin_blueprint = Blueprint("berlin", __name__)
@@ -18,7 +19,7 @@ def berlin_code(key):
     except Exception as e:
         logger.error(
             event="error retrieving key from database ",
-            error=str(e),
+            errors=format_errors(e, trace=traceback.format_exc()),
         )
 
         return jsonify({"key": key, "error": "Not found"}), 404
@@ -33,33 +34,27 @@ def berlin_search():
     state = request.args.get("state") or "gb"
     limit = request.args.get("limit", type=int) or 10
     lev_distance = request.args.get("lev_distance", type=int) or 2
-
-    if len(q) > 30:
-        # Find the first space before 30th character
-        if (loc := q[:30][::-1].find(" ")) > 0:
-            print(loc, q, q[:30][::-1])
-            q = q[:29 - loc]
-        # ...or take up to the 30th character if none.
-        else:
-            q = q[:30]
-
     try:
-        logger.info(
-            event="Querying database",
-            data={
-                "q": q,
-                "state": state,
-                "limit": limit,
-                "lev_distance": lev_distance,
-            },
-        )
-
+        query = ""
+        longerQuery = False
+        if len(q) > 30:
+            longerQuery = True
+            # Find the first space before 30th character
+            if (loc := q[:30][::-1].find(" ")) > 0:
+                query = q[: 29 - loc]
+            # ...or take up to the 30th character if none.
+            else:
+                query = q[:30]
+        else:
+            query = q
+                
         try:
-            result = db.query(q, state=state, limit=limit, lev_distance=lev_distance)
+            print(query)
+            result = db.query(query, state=state, limit=limit, lev_distance=lev_distance)
         except BaseException as e:
             logger.error(
                 event="error querying the database (rust) ",
-                errors=format_errors(e),
+                errors=format_errors(e, trace=traceback.format_exc()),
             )
             return (
                 jsonify({"error": "error querying the database"}),
@@ -74,18 +69,19 @@ def berlin_search():
             for loc in result
         ]
 
-        if matches:
+        locations = {"query": q, "matches": matches}
+        if matches and not longerQuery:
             start_idx = matches[0]["scores"]["offset"][0]
             end_idx = matches[0]["scores"]["offset"][1]
-            q = q[:start_idx] + q[end_idx:]
+            query = query[:start_idx] + query[end_idx:]
+            locations = {"query": query, "matches": matches}
 
-        locations = {"query": q, "matches": matches}
         return jsonify(locations), 200
 
     except Exception as e:
         logger.error(
-            event="error querying the database ",
-            error=str(e),
+            event="error querying the database",
+            errors=format_errors(e, trace=traceback.format_exc()),
         )
         return (
             jsonify({"error": "error querying the database"}),

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -66,7 +66,7 @@ class JsonRequestFormatter(json_log_formatter.JSONFormatter):
         payload["created_at"] = (
             datetime.utcnow().isoformat(timespec="milliseconds") + "Z"
         )
-        payload["event"] = "making request"
+        payload["event"] = "http request received"
         payload["severity"] = 3
         payload["http"] = {
             "method": record.args["m"],

--- a/tests/api/server_test.py
+++ b/tests/api/server_test.py
@@ -125,7 +125,7 @@ def test_search_too_long(test_client):
                 'score': 1010
             }
         }],
-        'query': 'two international'
+        'query': 'Are there two international statistics evaluations with three international values that the average is lower than'
     }
     print(response.json)
 

--- a/tests/gunicorn_test.py
+++ b/tests/gunicorn_test.py
@@ -1,12 +1,11 @@
-import re
-import warnings
+import sys
 import pytest
 import unittest
 from datetime import datetime
 from io import StringIO
 from unittest.mock import patch
 import logging.config
-from gunicorn_config import JsonRequestFormatter, JsonServerFormatter, logconfig_dict
+from gunicorn_config import JsonRequestFormatter, JsonServerInfoFormatter, JsonServerErrorFormatter, logconfig_dict
  
 
 class TestLogFormatting(unittest.TestCase):
@@ -14,9 +13,7 @@ class TestLogFormatting(unittest.TestCase):
         logging.config.dictConfig(logconfig_dict)
 
     @pytest.mark.filterwarnings("ignore::DeprecationWarning")
-    def test_request_log_formatting(self):
-        time = datetime.utcnow().isoformat(timespec="milliseconds") + "Z"
-
+    def test_request_formatting(self):
         record = logging.LogRecord(
             name="gunicorn.access",
             level=logging.INFO,
@@ -45,8 +42,6 @@ class TestLogFormatting(unittest.TestCase):
             expected={
                 'namespace': 'dp-nlp-berlin-api', 
                 'event': 'making request', 
-                # Why is created_at formatted to '2024-03-10T12:34:56.000+00:00Z', while when I run make run it formattes it correctly to"2024-03-11T20:10:16.475Z"
-                'created_at': time, 
                 'http': {
                     'method': 'GET', 
                     'scheme': 'https', 
@@ -55,7 +50,6 @@ class TestLogFormatting(unittest.TestCase):
                     'path': '/path/to/resource',
                     'query': 'param=value', 
                     'status_code': '200',
-                    'started_at': time, 
                 }, 
                 'severity': 3
             }
@@ -73,82 +67,8 @@ class TestLogFormatting(unittest.TestCase):
             self.assertEqual(expected["http"]["port"], formatted_log["http"]["port"])
             self.assertEqual(expected["http"]["path"], formatted_log["http"]["path"])
             self.assertEqual(expected["http"]["query"], formatted_log["http"]["query"])
-            self.assertEqual(expected["http"]["status_code"], formatted_log["http"]["status_code"])
-
-            # ask a bout this line
-            # AssertionError: '2024-03-11T20:59:27.919Z' != '2024-03-11T20:59:27.919+00:00Z'
-            # self.assertEqual(expected["http"]["started_at"], formatted_log["http"]["started_at"])
-
-    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
-    def test_request_error_formatting(self):
-        time = datetime.utcnow().isoformat(timespec="milliseconds") + "Z"
-
-        record = logging.LogRecord(
-            name="gunicorn.access",
-            level=logging.INFO,
-            pathname="",
-            lineno=0,
-            msg="Log message",
-            args={
-                "h": "127.0.0.1",
-                "U": "/path/to/resource",
-                "m": "GET",
-                "s": "500",
-                "q": "param=value",
-                "H": "https",
-                "{host}i": "1234"
-            },
-            exc_info=None,
-        )
-
-        stream_buffer = StringIO()
-
-        with patch("sys.stdout", stream_buffer):
-            formatter = JsonRequestFormatter()
-            formatted_log = formatter.json_record(event="testing request logs", extra={}, record=record)
-
-            expected={
-                'namespace': 'dp-nlp-berlin-api', 
-                'event': 'making request', 
-                # Why is created_at formatted to '2024-03-10T12:34:56.000+00:00Z', while when I run make run it formattes it correctly to"2024-03-11T20:10:16.475Z"
-                'created_at': time, 
-                'http': {
-                    'method': 'GET', 
-                    'scheme': 'https', 
-                    'host': '127.0.0.1',
-                    'port': '1234',
-                    'path': '/path/to/resource',
-                    'query': 'param=value', 
-                    'status_code': '500',
-                    'started_at': time, 
-                }, 
-                "error": [{
-                    "message": "received non-200 status code",
-                }],
-                'severity': 1
-            }
-
-
-            # Default required logs 
-            self.assertEqual(expected["namespace"], formatted_log["namespace"])
-            self.assertEqual(expected["event"], formatted_log["event"])
-            self.assertEqual(expected["severity"], formatted_log["severity"])
-
-            # Http logs 
-            self.assertEqual(expected["http"]["method"], formatted_log["http"]["method"])
-            self.assertEqual(expected["http"]["scheme"], formatted_log["http"]["scheme"])
-            self.assertEqual(expected["http"]["host"], formatted_log["http"]["host"])
-            self.assertEqual(expected["http"]["port"], formatted_log["http"]["port"])
-            self.assertEqual(expected["http"]["path"], formatted_log["http"]["path"])
-            self.assertEqual(expected["http"]["query"], formatted_log["http"]["query"])
-            self.assertEqual(expected["http"]["status_code"], formatted_log["http"]["status_code"])
-            
-            # Error logs 
-            self.assertEqual(expected["error"][0]["message"], formatted_log["error"][0]["message"])
-
-            # ask a bout this line
-            # AssertionError: '2024-03-11T20:59:27.919Z' != '2024-03-11T20:59:27.919+00:00Z'
-            # self.assertEqual(expected["http"]["started_at"], formatted_log["http"]["started_at"])
+            self.assertTrue(parsable_isoformat(time=formatted_log["http"]["started_at"]))
+            self.assertTrue(parsable_isoformat(formatted_log["created_at"]))
 
     def test_server_log_formatting(self):
         record = logging.LogRecord(
@@ -163,12 +83,11 @@ class TestLogFormatting(unittest.TestCase):
         stream_buffer = StringIO()
 
         with patch("sys.stdout", stream_buffer):
-            formatter = JsonServerFormatter()
+            formatter = JsonServerInfoFormatter()
             formatted_log = formatter.json_record(event="testing server logs", extra={}, record=record)
 
             expected={
                 'namespace': 'dp-nlp-berlin-api', 
-                'created_at': '2024-03-11T15:50:52.180+00:00Z', 
                 'event': 'server starting', 
                 'severity': 3
             }
@@ -176,55 +95,62 @@ class TestLogFormatting(unittest.TestCase):
             self.assertEqual(expected["namespace"], formatted_log["namespace"])
             self.assertEqual(expected["event"], formatted_log["event"])
             self.assertEqual(expected["severity"], formatted_log["severity"])
+            self.assertTrue(parsable_isoformat(formatted_log["created_at"]))
 
     def test_server_error_formatting(self):
-        record = logging.LogRecord(
-            name="gunicorn.error",
-            level=logging.ERROR,
-            pathname="",
-            lineno=0,
-            msg="specific err msg",
-            args=(),
-            exc_info=None,
-        )
-        stream_buffer = StringIO()
+        try:
+            # This will raise a NameError
+            nonexistent_variable
+        except:
+            # Capture the exception information to use as actual traceback for the logging
+            exc_info = sys.exc_info()
 
-        with patch("sys.stdout", stream_buffer):
-            formatter = JsonServerFormatter()
-            formatted_log = formatter.json_record(event="testing server logs", extra={}, record=record)
+            record = logging.LogRecord(
+                name="gunicorn.error",
+                level=logging.ERROR,
+                pathname="",
+                lineno=0,
+                msg="specific err msg",
+                args=(),
+                exc_info=exc_info,
+            )
 
-            expected={
-                'namespace': 'dp-nlp-berlin-api', 
-                'created_at': '2024-03-11T15:50:52.180+00:00Z', 
-                'event': 'server error',
-                'errors': [
-                    {
-                        "message": 'specific err msg',
-                        "data": {
-                            "level": record.levelname
+            stream_buffer = StringIO()
+
+            with patch("sys.stderr", stream_buffer):
+                formatter = JsonServerErrorFormatter()
+                formatted_log = formatter.json_record(event="testing server logs", extra={}, record=record)
+
+                expected={
+                    'namespace': 'dp-nlp-berlin-api', 
+                    'created_at': '2024-03-11T15:50:52.180+00:00Z', 
+                    'event': 'gunicorn has experienced an error',
+                    'errors': [
+                        {
+                            "message": 'specific err msg',
                         }
-                    }
-                ],
-                'severity': 1
-            }
+                    ],
+                    'severity': 1
+                }
 
-            # Default required logs 
-            self.assertEqual(expected["namespace"], formatted_log["namespace"])
-            self.assertEqual(expected["event"], formatted_log["event"])
-            self.assertEqual(expected["severity"], formatted_log["severity"])
+                # Default required logs 
+                self.assertEqual(expected["namespace"], formatted_log["namespace"])
+                self.assertEqual(expected["event"], formatted_log["event"])
+                self.assertEqual(expected["severity"], formatted_log["severity"])
 
-            # Error logs 
-            self.assertEqual(expected["errors"][0]["message"], formatted_log["errors"][0]["message"])
-            self.assertEqual(expected["errors"][0]["data"]["level"], formatted_log["errors"][0]["data"]["level"])
-
-# def check_created_at_regex(logs):
-#     print("aiodsjfioajsdfoikasd")
-#     match = re.search(r'"created_at": "(.*?),', logs).group(1)
-#     timestamp_pattern = r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$'
-#     if re.match(timestamp_pattern, match):
-#         return True
-#     else:
-#         return False
+                # Error logs 
+                self.assertEqual(expected["errors"][0]["message"], formatted_log["errors"][0]["message"])
+                assert "/gunicorn_test.py" in formatted_log["errors"][0]["error"][0]["file"]
+                assert "nonexistent_variable" in formatted_log["errors"][0]["error"][0]["function"]
+                assert formatted_log["errors"][0]["error"][0]["line"]
+            
+def parsable_isoformat(time):
+    desired_format = "%Y-%m-%dT%H:%M:%S.%fZ"
+    try:
+        datetime_obj = datetime.strptime(time, desired_format)
+        return True  # If parsing succeeds, the format is correct
+    except ValueError:
+        return False, "Invalid format"
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/gunicorn_test.py
+++ b/tests/gunicorn_test.py
@@ -1,0 +1,230 @@
+import re
+import warnings
+import pytest
+import unittest
+from datetime import datetime
+from io import StringIO
+from unittest.mock import patch
+import logging.config
+from gunicorn_config import JsonRequestFormatter, JsonServerFormatter, logconfig_dict
+ 
+
+class TestLogFormatting(unittest.TestCase):
+    def setUp(self):
+        logging.config.dictConfig(logconfig_dict)
+
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+    def test_request_log_formatting(self):
+        time = datetime.utcnow().isoformat(timespec="milliseconds") + "Z"
+
+        record = logging.LogRecord(
+            name="gunicorn.access",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="Log message",
+            args={
+                "h": "127.0.0.1",
+                "U": "/path/to/resource",
+                "m": "GET",
+                "s": "200",
+                "q": "param=value",
+                "H": "https",
+                "{host}i": "1234"
+                
+            },
+            exc_info=None,
+        )
+
+        stream_buffer = StringIO()
+
+        with patch("sys.stdout", stream_buffer):
+            formatter = JsonRequestFormatter()
+            formatted_log = formatter.json_record(event="testing request logs", extra={}, record=record)
+
+            expected={
+                'namespace': 'dp-nlp-berlin-api', 
+                'event': 'making request', 
+                # Why is created_at formatted to '2024-03-10T12:34:56.000+00:00Z', while when I run make run it formattes it correctly to"2024-03-11T20:10:16.475Z"
+                'created_at': time, 
+                'http': {
+                    'method': 'GET', 
+                    'scheme': 'https', 
+                    'host': '127.0.0.1',
+                    'port': '1234',
+                    'path': '/path/to/resource',
+                    'query': 'param=value', 
+                    'status_code': '200',
+                    'started_at': time, 
+                }, 
+                'severity': 3
+            }
+
+
+            # Default required logs 
+            self.assertEqual(expected["namespace"], formatted_log["namespace"])
+            self.assertEqual(expected["event"], formatted_log["event"])
+            self.assertEqual(expected["severity"], formatted_log["severity"])
+
+            # Http logs 
+            self.assertEqual(expected["http"]["method"], formatted_log["http"]["method"])
+            self.assertEqual(expected["http"]["scheme"], formatted_log["http"]["scheme"])
+            self.assertEqual(expected["http"]["host"], formatted_log["http"]["host"])
+            self.assertEqual(expected["http"]["port"], formatted_log["http"]["port"])
+            self.assertEqual(expected["http"]["path"], formatted_log["http"]["path"])
+            self.assertEqual(expected["http"]["query"], formatted_log["http"]["query"])
+            self.assertEqual(expected["http"]["status_code"], formatted_log["http"]["status_code"])
+
+            # ask a bout this line
+            # AssertionError: '2024-03-11T20:59:27.919Z' != '2024-03-11T20:59:27.919+00:00Z'
+            # self.assertEqual(expected["http"]["started_at"], formatted_log["http"]["started_at"])
+
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+    def test_request_error_formatting(self):
+        time = datetime.utcnow().isoformat(timespec="milliseconds") + "Z"
+
+        record = logging.LogRecord(
+            name="gunicorn.access",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="Log message",
+            args={
+                "h": "127.0.0.1",
+                "U": "/path/to/resource",
+                "m": "GET",
+                "s": "500",
+                "q": "param=value",
+                "H": "https",
+                "{host}i": "1234"
+            },
+            exc_info=None,
+        )
+
+        stream_buffer = StringIO()
+
+        with patch("sys.stdout", stream_buffer):
+            formatter = JsonRequestFormatter()
+            formatted_log = formatter.json_record(event="testing request logs", extra={}, record=record)
+
+            expected={
+                'namespace': 'dp-nlp-berlin-api', 
+                'event': 'making request', 
+                # Why is created_at formatted to '2024-03-10T12:34:56.000+00:00Z', while when I run make run it formattes it correctly to"2024-03-11T20:10:16.475Z"
+                'created_at': time, 
+                'http': {
+                    'method': 'GET', 
+                    'scheme': 'https', 
+                    'host': '127.0.0.1',
+                    'port': '1234',
+                    'path': '/path/to/resource',
+                    'query': 'param=value', 
+                    'status_code': '500',
+                    'started_at': time, 
+                }, 
+                "error": [{
+                    "message": "received non-200 status code",
+                }],
+                'severity': 1
+            }
+
+
+            # Default required logs 
+            self.assertEqual(expected["namespace"], formatted_log["namespace"])
+            self.assertEqual(expected["event"], formatted_log["event"])
+            self.assertEqual(expected["severity"], formatted_log["severity"])
+
+            # Http logs 
+            self.assertEqual(expected["http"]["method"], formatted_log["http"]["method"])
+            self.assertEqual(expected["http"]["scheme"], formatted_log["http"]["scheme"])
+            self.assertEqual(expected["http"]["host"], formatted_log["http"]["host"])
+            self.assertEqual(expected["http"]["port"], formatted_log["http"]["port"])
+            self.assertEqual(expected["http"]["path"], formatted_log["http"]["path"])
+            self.assertEqual(expected["http"]["query"], formatted_log["http"]["query"])
+            self.assertEqual(expected["http"]["status_code"], formatted_log["http"]["status_code"])
+            
+            # Error logs 
+            self.assertEqual(expected["error"][0]["message"], formatted_log["error"][0]["message"])
+
+            # ask a bout this line
+            # AssertionError: '2024-03-11T20:59:27.919Z' != '2024-03-11T20:59:27.919+00:00Z'
+            # self.assertEqual(expected["http"]["started_at"], formatted_log["http"]["started_at"])
+
+    def test_server_log_formatting(self):
+        record = logging.LogRecord(
+            name="gunicorn.error",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="server starting",
+            args=(),
+            exc_info=None,
+        )
+        stream_buffer = StringIO()
+
+        with patch("sys.stdout", stream_buffer):
+            formatter = JsonServerFormatter()
+            formatted_log = formatter.json_record(event="testing server logs", extra={}, record=record)
+
+            expected={
+                'namespace': 'dp-nlp-berlin-api', 
+                'created_at': '2024-03-11T15:50:52.180+00:00Z', 
+                'event': 'server starting', 
+                'severity': 3
+            }
+
+            self.assertEqual(expected["namespace"], formatted_log["namespace"])
+            self.assertEqual(expected["event"], formatted_log["event"])
+            self.assertEqual(expected["severity"], formatted_log["severity"])
+
+    def test_server_error_formatting(self):
+        record = logging.LogRecord(
+            name="gunicorn.error",
+            level=logging.ERROR,
+            pathname="",
+            lineno=0,
+            msg="specific err msg",
+            args=(),
+            exc_info=None,
+        )
+        stream_buffer = StringIO()
+
+        with patch("sys.stdout", stream_buffer):
+            formatter = JsonServerFormatter()
+            formatted_log = formatter.json_record(event="testing server logs", extra={}, record=record)
+
+            expected={
+                'namespace': 'dp-nlp-berlin-api', 
+                'created_at': '2024-03-11T15:50:52.180+00:00Z', 
+                'event': 'server error',
+                'errors': [
+                    {
+                        "message": 'specific err msg',
+                        "data": {
+                            "level": record.levelname
+                        }
+                    }
+                ],
+                'severity': 1
+            }
+
+            # Default required logs 
+            self.assertEqual(expected["namespace"], formatted_log["namespace"])
+            self.assertEqual(expected["event"], formatted_log["event"])
+            self.assertEqual(expected["severity"], formatted_log["severity"])
+
+            # Error logs 
+            self.assertEqual(expected["errors"][0]["message"], formatted_log["errors"][0]["message"])
+            self.assertEqual(expected["errors"][0]["data"]["level"], formatted_log["errors"][0]["data"]["level"])
+
+# def check_created_at_regex(logs):
+#     print("aiodsjfioajsdfoikasd")
+#     match = re.search(r'"created_at": "(.*?),', logs).group(1)
+#     timestamp_pattern = r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$'
+#     if re.match(timestamp_pattern, match):
+#         return True
+#     else:
+#         return False
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/gunicorn_test.py
+++ b/tests/unit/gunicorn_test.py
@@ -1,18 +1,18 @@
+import logging.config
 import sys
-import pytest
 import unittest
+
 from datetime import datetime
 from io import StringIO
 from unittest.mock import patch
-import logging.config
-from gunicorn_config import JsonRequestFormatter, JsonServerInfoFormatter, JsonServerErrorFormatter, logconfig_dict
- 
+from gunicorn_config import (JsonRequestFormatter, JsonServerErrorFormatter,
+                             JsonServerInfoFormatter, logconfig_dict)
+
 
 class TestLogFormatting(unittest.TestCase):
     def setUp(self):
         logging.config.dictConfig(logconfig_dict)
 
-    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_request_formatting(self):
         record = logging.LogRecord(
             name="gunicorn.access",
@@ -100,8 +100,8 @@ class TestLogFormatting(unittest.TestCase):
     def test_server_error_formatting(self):
         try:
             # This will raise a NameError
-            nonexistent_variable
-        except:
+            nonexistent_variable # noqa
+        except Exception:
             # Capture the exception information to use as actual traceback for the logging
             exc_info = sys.exc_info()
 
@@ -124,7 +124,7 @@ class TestLogFormatting(unittest.TestCase):
                 expected={
                     'namespace': 'dp-nlp-berlin-api', 
                     'created_at': '2024-03-11T15:50:52.180+00:00Z', 
-                    'event': 'gunicorn has experienced an error',
+                    'event': 'server has experienced an error',
                     'errors': [
                         {
                             "message": 'specific err msg',
@@ -147,7 +147,7 @@ class TestLogFormatting(unittest.TestCase):
 def parsable_isoformat(time):
     desired_format = "%Y-%m-%dT%H:%M:%S.%fZ"
     try:
-        datetime_obj = datetime.strptime(time, desired_format)
+        _ = datetime.strptime(time, desired_format)
         return True  # If parsing succeeds, the format is correct
     except ValueError:
         return False, "Invalid format"

--- a/tests/unit/gunicorn_test.py
+++ b/tests/unit/gunicorn_test.py
@@ -41,7 +41,7 @@ class TestLogFormatting(unittest.TestCase):
 
             expected={
                 'namespace': 'dp-nlp-berlin-api', 
-                'event': 'making request', 
+                'event': 'http request received', 
                 'http': {
                     'method': 'GET', 
                     'scheme': 'https', 


### PR DESCRIPTION
### What

Changed the gunicorn logger to create logs to stdout and stderr based on loglevel info or error.
Changed the gunicorn logs to log stacktraces as well as per ons standards
file, function, line
Added compliance tests for gunicorn logger.
Updated spike issue fix to make sure it provides the correct query to Category.

### How to review

Check the CI rules have passed as well as that the concourse image is running.
Check the logs appeal to the ONS standards.

### Who can review

Linden.